### PR TITLE
Added a WSA version of the YarnSpinner project

### DIFF
--- a/YarnSpinner.sln
+++ b/YarnSpinner.sln
@@ -1,8 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
-MinimumVisualStudioVersion = 10.0.40219.1
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinnerConsole", "YarnSpinnerConsole\YarnSpinnerConsole.csproj", "{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7A162B42-C144-4C15-9ABC-BE5898622C32}"
@@ -11,49 +9,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinner", "YarnSpinner\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinnerTests", "YarnSpinnerTests\YarnSpinnerTests.csproj", "{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinner_WSA", "YarnSpinner\YarnSpinner_WSA.csproj", "{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|x86.ActiveCfg = Debug|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|x86.Build.0 = Debug|x86
-		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|Any CPU.ActiveCfg = Release|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|x86.ActiveCfg = Release|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|x86.Build.0 = Release|x86
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.Build.0 = Debug|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.ActiveCfg = Release|Any CPU
-		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.Build.0 = Release|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.Build.0 = Debug|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|Any CPU.Build.0 = Release|Any CPU
 		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.ActiveCfg = Release|Any CPU
 		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.Build.0 = Release|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|x86.Build.0 = Debug|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|x86.ActiveCfg = Release|Any CPU
-		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|x86.Build.0 = Release|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		version = 0.9

--- a/YarnSpinner.sln
+++ b/YarnSpinner.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinnerConsole", "YarnSpinnerConsole\YarnSpinnerConsole.csproj", "{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7A162B42-C144-4C15-9ABC-BE5898622C32}"
@@ -9,26 +11,49 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinner", "YarnSpinner\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinnerTests", "YarnSpinnerTests\YarnSpinnerTests.csproj", "{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YarnSpinner_WSA", "YarnSpinner\YarnSpinner_WSA.csproj", "{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|x86.ActiveCfg = Debug|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Debug|x86.Build.0 = Debug|x86
+		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|Any CPU.ActiveCfg = Release|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|x86.ActiveCfg = Release|x86
 		{20B32C04-790E-4A50-BF32-20EA5C3CB0E2}.Release|x86.Build.0 = Release|x86
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.Build.0 = Debug|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.ActiveCfg = Release|Any CPU
-		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.Build.0 = Release|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.ActiveCfg = Release|Any CPU
 		{6C3B03D2-2E89-4EC3-A022-E84053A7B17F}.Release|x86.Build.0 = Release|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Debug|x86.Build.0 = Debug|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.ActiveCfg = Release|Any CPU
+		{24F90A1D-B1CA-4E0F-8BD2-A91D8B443855}.Release|x86.Build.0 = Release|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Debug|x86.Build.0 = Debug|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|x86.ActiveCfg = Release|Any CPU
+		{7EDB2A9F-44BF-4BFD-AD0C-AEC84B2DA955}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		version = 0.9

--- a/YarnSpinner/Analyser.cs
+++ b/YarnSpinner/Analyser.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#if NETFX_CORE
+using System.Reflection;
+#endif
+
 namespace Yarn.Analysis
 {
 	public class Diagnosis {
@@ -88,17 +92,31 @@ namespace Yarn.Analysis
 				if (_defaultAnalyserClasses == null) {
 					classes = new List<Type> ();
 
-					var assembly = this.GetType().Assembly;
+                    IEnumerable<Type> assemblyTypes;
+#if NETFX_CORE
+                    var assembly = this.GetType().GetTypeInfo().Assembly;
+                    assemblyTypes = assembly.ExportedTypes;
+#else
+                    var assembly = this.GetType().Assembly;
+                    assemblyTypes = assembly.GetTypes();
+#endif
 
-					foreach (var type in assembly.GetTypes()) {
-						if (type.IsSubclassOf(typeof(Analysis.CompiledProgramAnalyser)) &&
-							type.IsAbstract == false) {
+                    foreach (var type in assemblyTypes)
+                    {
+#if NETFX_CORE
+                        TypeInfo typeInfo = type.GetTypeInfo();
+#else
+                        Type typeInfo = type;
+#endif
+                        if (typeInfo.IsSubclassOf(typeof(Analysis.CompiledProgramAnalyser)) &&
+                            typeInfo.IsAbstract == false)
+                        {
 
-							classes.Add (type);
+                            classes.Add(type);
 
-						}
-					}
-					_defaultAnalyserClasses = classes;
+                        }
+                    }
+                    _defaultAnalyserClasses = classes;
 				}
 
 				return _defaultAnalyserClasses;

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -173,8 +173,9 @@ namespace Yarn {
 
 		}
 
-		// Load a file from disk.
-		public void LoadFile(string fileName, bool showTokens = false, bool showParseTree = false, string onlyConsiderNode=null) {
+#if !NETFX_CORE
+        // Load a file from disk.
+        public void LoadFile(string fileName, bool showTokens = false, bool showParseTree = false, string onlyConsiderNode=null) {
 			System.IO.StreamReader reader = new System.IO.StreamReader(fileName);
 			string inputString = reader.ReadToEnd ();
 			reader.Close ();
@@ -182,6 +183,7 @@ namespace Yarn {
 			LoadString (inputString, fileName, showTokens, showParseTree, onlyConsiderNode);
 
 		}
+#endif
 
 		// Ask the loader to parse a string. Returns the number of nodes that were loaded.
 		public void LoadString(string text, string fileName="<input>", bool showTokens=false, bool showParseTree=false, string onlyConsiderNode=null) {
@@ -352,7 +354,7 @@ namespace Yarn {
 
 			public StandardLibrary() {
 
-				#region Operators
+#region Operators
 
 				this.RegisterFunction(TokenType.Add.ToString(), 2, delegate(Value[] parameters) {
 					return parameters[0] + parameters[1];
@@ -418,7 +420,7 @@ namespace Yarn {
 					return !parameters[0].AsBool;
 				});
 
-				#endregion Operators
+#endregion Operators
 			}
 		}
 

--- a/YarnSpinner/JsonParser.cs
+++ b/YarnSpinner/JsonParser.cs
@@ -127,6 +127,30 @@ namespace Json
     }
 #endif
 
+#if NETFX_CORE
+    public enum BindingFlags
+    {
+        Instance = 4,
+        Static = 8,
+        Public = 16,
+    }
+
+    public static class ReflectionExtensions
+    {
+        public static PropertyInfo[] GetProperties(this Type type, BindingFlags flags)
+        {
+            var props = type.GetRuntimeProperties();
+
+            return props.Where(p =>
+             ((flags.HasFlag(BindingFlags.Static) == (p.GetMethod != null && p.GetMethod.IsStatic)) ||
+               (flags.HasFlag(BindingFlags.Instance) == (p.GetMethod != null && !p.GetMethod.IsStatic))
+             ) &&
+             (flags.HasFlag(BindingFlags.Public) == (p.GetMethod != null && p.GetMethod.IsPublic)
+             )).ToArray();
+        }
+    }
+#endif
+
     /// <summary>
     /// A parser for JSON.
     /// <seealso cref="http://json.org" />

--- a/YarnSpinner/Parser.cs
+++ b/YarnSpinner/Parser.cs
@@ -32,8 +32,10 @@ using System.Text;
 
 namespace Yarn {
 
-	// An exception representing something going wrong during parsing
-	[Serializable]
+    // An exception representing something going wrong during parsing
+#if !NETFX_CORE
+    [Serializable]
+#endif
 	internal class ParseException : Exception {
 
 		internal int lineNumber = 0;
@@ -94,7 +96,7 @@ namespace Yarn {
 			return sb.ToString ();
 		}
 
-		#region Parse Nodes
+#region Parse Nodes
 		// Base class for nodes in th parse tree
 		internal abstract class ParseNode {
 
@@ -1226,7 +1228,7 @@ namespace Yarn {
 				return Tab (indentLevel, operatorType.ToString ());
 			}
 		}
-		#endregion Parse Nodes
+#endregion Parse Nodes
 
 		// Use a queue since we're continuously consuming them as 
 		// we parse

--- a/YarnSpinner/Value.cs
+++ b/YarnSpinner/Value.cs
@@ -101,8 +101,8 @@ namespace Yarn
 		// Create a value with a C# object
 		public Value (object value)
 		{
-			// Copy an existing value
-			if (typeof(Value).IsInstanceOfType(value)) {
+            // Copy an existing value
+            if (value is Value) {
 				var otherValue = value as Value;
 				type = otherValue.type;
 				switch (type) {

--- a/YarnSpinner/YarnSpinner_WSA.csproj
+++ b/YarnSpinner/YarnSpinner_WSA.csproj
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7edb2a9f-44bf-4bfd-ad0c-aec84b2da955}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>YarnSpinner_WSA</RootNamespace>
+    <AssemblyName>YarnSpinner</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+	<ReleaseVersion>0.9</ReleaseVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;NETFX_CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>False</ConsolePause>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="cp ${TargetPath} &quot;Unity/Assets/Yarn Spinner/Code/&quot; " workingdir="${SolutionDir}" />
+      </CustomCommands>
+    </CustomCommands>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+	<DefineConstants>NETFX_CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>False</ConsolePause>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="cp ${TargetPath} &quot;Unity/Assets/Yarn Spinner/Code/&quot; " workingdir="${SolutionDir}" />
+      </CustomCommands>
+    </CustomCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <TargetPlatform Include="WindowsPhoneApp, Version=8.1" />
+    <TargetPlatform Include="Windows, Version=8.1" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>
+


### PR DESCRIPTION
Added a new standalone .csproj to build Yarn for Window Store Apps. Fixes issue #42.
After building YarnSpinner using this project, follow the steps found here:

http://docs.unity3d.com/Manual/windowsstore-plugins.html

For any future updates, please be careful of using reflection, type information, or file IO since WSA generally handles them differently.
