### PR TITLE
Convenience setters for variable storage

### DIFF
--- a/Unity/Assets/YarnSpinner/Code/DialogueRunner.cs
+++ b/Unity/Assets/YarnSpinner/Code/DialogueRunner.cs
@@ -482,28 +482,27 @@ namespace Yarn.Unity
     /// Scripts that can act as a variable storage should subclass this
     public abstract class VariableStorageBehaviour : MonoBehaviour, Yarn.VariableStorage
     {
-
-        /// Not implemented here
-        public virtual void SetNumber (string variableName, float number)
-        {
-            throw new System.NotImplementedException ();
-        }
-
-        /// Not implemented here
-        public virtual float GetNumber (string variableName)
-        {
-            throw new System.NotImplementedException ();
-        }
-
         /// Get a value
-        public virtual Value GetValue(string variableName) {
-            return new Yarn.Value(this.GetNumber(variableName));
+        public abstract Value GetValue(string variableName);
+
+        public virtual void SetValue(string variableName, float floatValue)
+        {
+            Value value = new Yarn.Value(floatValue);
+            this.SetValue(variableName, value);
+        }
+        public virtual void SetValue(string variableName, bool stringValue)
+        {
+            Value value = new Yarn.Value(stringValue);
+            this.SetValue(variableName, value);
+        }
+        public virtual void SetValue(string variableName, string boolValue)
+        {
+            Value value = new Yarn.Value(boolValue);
+            this.SetValue(variableName, value);
         }
 
         /// Set a value
-        public virtual void SetValue(string variableName, Value value) {
-            this.SetNumber(variableName, value.AsNumber);
-        }
+        public abstract void SetValue(string variableName, Value value);
 
         /// Not implemented here
         public virtual void Clear ()

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -63,23 +63,32 @@ namespace Yarn {
 
     /// Where we turn to for storing and loading variable data.
     public interface VariableStorage {
-
-        [Obsolete] void SetNumber(string variableName, float number);
-        [Obsolete] float GetNumber(string variableName);
         void SetValue(string variableName, Value value);
+
+        // some convenience setters
+        void SetValue(string variableName, string stringValue);
+        void SetValue(string variableName, float floatValue);
+        void SetValue(string variableName, bool boolValue);
+
         Value GetValue(string variableName);
         void Clear();
     }
 
     public abstract class BaseVariableStorage : VariableStorage {
-        [Obsolete]
-        public void SetNumber(string variableName, float number) {
-            this.SetValue(variableName, new Value(number));
+        public virtual void SetValue(string variableName, string stringValue)
+        {
+            Value val = Yarn.Value(stringValue);
+            SetValue(variableName, val);
         }
-
-        [Obsolete]
-        public float GetNumber(string variableName) {
-            return this.GetValue(variableName).AsNumber;
+        public virtual void SetValue(string variableName, float floatValue)
+        {
+            Value val = Yarn.Value(floatValue);
+            SetValue(variableName, val);
+        }
+        public virtual void SetValue(string variableName, bool boolValue)
+        {
+            Value val = Yarn.Value(boolValue);
+            SetValue(variableName, val);
         }
 
         public abstract void SetValue(string variableName, Value value);
@@ -106,6 +115,22 @@ namespace Yarn {
         public override void SetValue(string variableName, Value value)
         {
             variables[variableName] = value;
+        }
+
+        public override void SetValue(string variableName, string stringValue)
+        {
+            Value strVal = new Yarn.Value(stringValue);
+            variables[variables] = strVal;
+        }
+        public override void SetValue(string variableName, float floatValue)
+        {
+            Value fltVal = new Yarn.Value(floatValue);
+            variables[variables] = fltVal;
+        }
+        public override void SetValue(string variableName, bool boolValue)
+        {
+            Value boolVal = new Yarn.Value(boolValue);
+            variables[variables] = boolVal;
         }
 
         public override Value GetValue(string variableName)

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -77,17 +77,17 @@ namespace Yarn {
     public abstract class BaseVariableStorage : VariableStorage {
         public virtual void SetValue(string variableName, string stringValue)
         {
-            Value val = Yarn.Value(stringValue);
+            Value val = new Yarn.Value(stringValue);
             SetValue(variableName, val);
         }
         public virtual void SetValue(string variableName, float floatValue)
         {
-            Value val = Yarn.Value(floatValue);
+            Value val = new Yarn.Value(floatValue);
             SetValue(variableName, val);
         }
         public virtual void SetValue(string variableName, bool boolValue)
         {
-            Value val = Yarn.Value(boolValue);
+            Value val = new Yarn.Value(boolValue);
             SetValue(variableName, val);
         }
 
@@ -120,17 +120,17 @@ namespace Yarn {
         public override void SetValue(string variableName, string stringValue)
         {
             Value strVal = new Yarn.Value(stringValue);
-            variables[variables] = strVal;
+            variables[variableName] = strVal;
         }
         public override void SetValue(string variableName, float floatValue)
         {
             Value fltVal = new Yarn.Value(floatValue);
-            variables[variables] = fltVal;
+            variables[variableName] = fltVal;
         }
         public override void SetValue(string variableName, bool boolValue)
         {
             Value boolVal = new Yarn.Value(boolValue);
-            variables[variables] = boolVal;
+            variables[variableName] = boolVal;
         }
 
         public override Value GetValue(string variableName)

--- a/YarnSpinner/YarnSpinner.csproj
+++ b/YarnSpinner/YarnSpinner.csproj
@@ -32,7 +32,7 @@
       <CustomCommands>
         <Command>
           <type>AfterBuild</type>
-          <command>cp ${TargetPath} "Unity/Assets/Yarn Spinner/Code/" </command>
+          <command>cp ${TargetPath} "Unity/Assets/YarnSpinner/Code/" </command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
       </CustomCommands>

--- a/YarnSpinnerConsole/Main.cs
+++ b/YarnSpinnerConsole/Main.cs
@@ -289,7 +289,7 @@ namespace Yarn
                 }
                 var name = entry[0];
 
-                impl.SetNumber(name, value);
+                impl.SetValue(name, value);
             }
 
             if (options.automaticallySelectFirstOption == true)
@@ -657,14 +657,17 @@ namespace Yarn
                 Note(message);
             }
 
-            public virtual void SetNumber(string variableName, float number)
+            public virtual void SetValue(string variableName, float floatValue)
             {
-                variableStore.SetValue(variableName, new Value(number));
+                variableStore.SetValue(variableName, floatValue);
             }
-
-            public virtual float GetNumber(string variableName)
+            public virtual void SetValue(string variableName, string stringValue)
             {
-                return variableStore.GetValue(variableName).AsNumber;
+                variableStore.SetValue(variableName, stringValue);
+            }
+            public virtual void SetValue(string variableName, bool boolValue)
+            {
+                variableStore.SetValue(variableName, boolValue);
             }
 
             public virtual void SetValue(string variableName, Value value)


### PR DESCRIPTION
This provides three new convenience setters (all called SetValue) on the VariableStorage interface as well as providing implementations of them on the pre-made instances of the storage.
Also removes the obsolete get/set number method call as this supersedes them.