### PR TITLE
Bugfix: Select system's language instead of null ref

### DIFF
--- a/Unity/Assets/YarnSpinner/Editor/YarnImporterEditor.cs
+++ b/Unity/Assets/YarnSpinner/Editor/YarnImporterEditor.cs
@@ -21,19 +21,19 @@ public class YarnImporterEditor : ScriptedImporterEditor {
 
     public override void OnEnable() {
         base.OnEnable();
-            cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures)
-                .Where(c => c.Name != "")
-                .Select(c => new Culture { Name = c.Name, DisplayName = c.DisplayName })
-                .Append(new Culture { Name = "mi", DisplayName = "Maori" })
-                .OrderBy(c => c.DisplayName)
-                .ToArray();
+        cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Where(c => c.Name != "")
+            .Select(c => new Culture { Name = c.Name, DisplayName = c.DisplayName })
+            .Append(new Culture { Name = "mi", DisplayName = "Maori" })
+            .OrderBy(c => c.DisplayName)
+            .ToArray();
 
-            baseLanguageProp = serializedObject.FindProperty("baseLanguageID");
+        baseLanguageProp = serializedObject.FindProperty("baseLanguageID");
 
-            selectedLanguageIndex = cultureInfo.Select((culture, index) => new { culture, index })
-                .FirstOrDefault(pair => pair.culture.Name == baseLanguageProp.stringValue)
-                .index;
-            selectedNewTranslationLanguageIndex = selectedLanguageIndex;
+        selectedLanguageIndex = cultureInfo.Select((culture, index) => new { culture, index })
+            .FirstOrDefault(pair => pair.culture.Name == baseLanguageProp.stringValue)
+            .index;
+        selectedNewTranslationLanguageIndex = selectedLanguageIndex;
     }
 
     public override void OnDisable() {

--- a/Unity/Assets/YarnSpinner/Editor/YarnImporterEditor.cs
+++ b/Unity/Assets/YarnSpinner/Editor/YarnImporterEditor.cs
@@ -30,9 +30,16 @@ public class YarnImporterEditor : ScriptedImporterEditor {
 
         baseLanguageProp = serializedObject.FindProperty("baseLanguageID");
 
-        selectedLanguageIndex = cultureInfo.Select((culture, index) => new { culture, index })
-            .FirstOrDefault(pair => pair.culture.Name == baseLanguageProp.stringValue)
-            .index;
+        if (string.IsNullOrEmpty(baseLanguageProp.stringValue)) {
+            selectedLanguageIndex = cultureInfo.
+                Select((culture, index) => new { culture, index })
+                .FirstOrDefault(element => element.culture.Name == CultureInfo.CurrentCulture.Name)
+                .index;
+        } else {
+            selectedLanguageIndex = cultureInfo.Select((culture, index) => new { culture, index })
+                .FirstOrDefault(pair => pair.culture.Name == baseLanguageProp.stringValue)
+                .index;
+        }
         selectedNewTranslationLanguageIndex = selectedLanguageIndex;
     }
 


### PR DESCRIPTION
Due to a missing null check, there will be a null ref error the first time a yarn file is drawn in Unity's inspector. This PR fixes that and treats this case by retrieving the user's default language as default.