### PR TITLE
Compare null values and number values as numbers

### DIFF
--- a/YarnSpinner/Value.cs
+++ b/YarnSpinner/Value.cs
@@ -186,6 +186,12 @@ namespace Yarn
                 }
             }
 
+            // Compare null value with numbers as a number, this avoids returning false on unasigned variables.
+            if (this.type == Type.Null && other.type == Type.Number)
+            {
+                return this.AsNumber.CompareTo (other.numberValue);
+            }
+
             // try to do a string test at that point!
             return string.Compare(this.AsString, other.AsString, StringComparison.InvariantCulture);
         }


### PR DESCRIPTION
Hello, I have started using YarnSpinner recently in my hobby project and stumbled upon a headache while trying to write quick dialogue logic.

First of all I am sorry in advance that I am not 100% sure if this pull request provides expected behaviour as I quite frankly havent had time to fully familiarize myself with all of Yarn code, but I dont see why it shouldnt work well like this.

The problem:
---

Atm when variable is not set, the variable storage returns default Value.Null, 
this compared to a number value, for example:

<<if $unassignedVariable >= 2>>

Always returns FALSE.

The solution:
---

Introduce additional check inside Value.CompareTo() method and provide return value that compares Number against Number if Type is NULL.

---

I think while the problem makes sense programatically, it kinda goes against basic expectations of a non programming person trying to write dialogue script in Yarn, also my expectations while quickly writing a testing script.

Setting default values to avoid this issue is a solution, but I think my proposed behaviour is in favour of Yarn simplicity promise.