### PR TITLE
Fix for shortcut options failing to parse under certain circumstances.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,3 +172,10 @@ Some of these changes are intentionally made to clean up some of the cruft we've
 Some of these changes we can see exactly how they will work and integrate, others will need to change as we get closer.
 Later releases are designed to have much larger broad strokes of features instead of specifics like in V1.0.
 As a release comes out we can take a look at the road map again, work out what features and needs should go into the next release and update the road map appropriately.
+
+# GSoC 2020 Ideas
+
+* Godot Engine Support
+* Game Maker Engine Support
+* Improvements and new features for YS VS Code extension
+* Bundles of features from above roadmap

--- a/Tests/TestCases/Options.yarn.txt
+++ b/Tests/TestCases/Options.yarn.txt
@@ -2,6 +2,13 @@ title: Start
 ---
 // Testing options
 
+// This should parse successfully
+<<if true>>
+    -> Option1
+<<else>>
+    -> Option2
+<<endif>>
+
 // Expect 2 options (the second one in the following group of three
 // will not be run) and select the first one
 <<prepare_for_options(2,0)>>

--- a/Unity/Assets/YarnSpinner/Editor/YarnSpinnerUnity.Editor.asmdef
+++ b/Unity/Assets/YarnSpinner/Editor/YarnSpinnerUnity.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "YarnSpinnerUnity.Editor",
+    "references": [
+        "GUID:34aa492b82754644eac2f903cd496268"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Unity/Assets/YarnSpinner/Editor/YarnSpinnerUnity.Editor.asmdef.meta
+++ b/Unity/Assets/YarnSpinner/Editor/YarnSpinnerUnity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3a299c53e4c683b4eb4a04c9ad9e648f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/YarnSpinner/Examples/Space/Scripts/NodeVisitedTracker.cs
+++ b/Unity/Assets/YarnSpinner/Examples/Space/Scripts/NodeVisitedTracker.cs
@@ -9,7 +9,9 @@ public class NodeVisitedTracker : MonoBehaviour
 {
 
     // The dialogue runner that we want to attach the 'visited' function to
+#pragma warning disable 0649
     [SerializeField] Yarn.Unity.DialogueRunner dialogueRunner;
+#pragma warning restore 0649
 
     private HashSet<string> _visitedNodes = new HashSet<string>();
 

--- a/Unity/Assets/YarnSpinner/Scripts/DialogueRunner.cs
+++ b/Unity/Assets/YarnSpinner/Scripts/DialogueRunner.cs
@@ -87,7 +87,9 @@ namespace Yarn.Unity
 
         /// A Unity event that receives the name of the node that just
         /// finished running
+#pragma warning disable 0649
         [SerializeField] StringUnityEvent onNodeComplete;
+#pragma warning restore 0649
 
         // A flag used to note when we call into a blocking command
         // handler, but it calls its complete handler immediately -

--- a/Unity/Assets/YarnSpinner/YarnSpinnerUnity.asmdef
+++ b/Unity/Assets/YarnSpinner/YarnSpinnerUnity.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "YarnSpinnerUnity",
+    "references": [
+        "GUID:bae83085c871e65499349309526e7f94"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.firelight.fmodunityintegration",
+            "expression": "2.0.0",
+            "define": "FMOD_2_OR_NEWER"
+        }
+    ]
+}

--- a/Unity/Assets/YarnSpinner/YarnSpinnerUnity.asmdef.meta
+++ b/Unity/Assets/YarnSpinner/YarnSpinnerUnity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 34aa492b82754644eac2f903cd496268
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/YarnSpinner/package.json
+++ b/Unity/Assets/YarnSpinner/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dev.secretlab.yarnspinner",
+  "version": "1.0.2",
+  "displayName": "Yarn Spinner",
+  "description": "Yarn is a language that's designed to make it super easy to create interactive dialogue for games. Yarn's similar in style to Twine, so if you already know that, you'll be right at home! If you don't, that's cool - Yarn's syntax is extremely minimal, and there's not much there to learn. The Yarn language is used in a number of cool games, including Night In The Woods and Knights and Bikes.",
+  "unity": "2018.1",
+  "keywords": [
+    "Dialogue",
+    "Yarn"
+  ],
+  "author": {
+    "name": "Secret Lab",
+    "url": "https://github.com/YarnSpinnerTool/YarnSpinner"
+  },
+  "hideInEditor": false,
+  "type": "tool"
+}

--- a/Unity/Assets/YarnSpinner/package.json.meta
+++ b/Unity/Assets/YarnSpinner/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6335304c5696c743aedd0a77a6533ad
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/YarnSpinner.Compiler/Compiler.cs
+++ b/YarnSpinner.Compiler/Compiler.cs
@@ -115,8 +115,6 @@ namespace Yarn.Compiler
                         {
                             outputLines[outputLines.Count - 1] = outputLines[outputLines.Count - 1] + INDENT;
                         }
-
-                        shouldTrackNextIndentation = false;
                     }
                     // have we finished with the current block of statements
                     else if (lineIndent < previous.depth)
@@ -139,12 +137,9 @@ namespace Yarn.Compiler
                             }
                         }
                     }
-                    else
-                    {
-                        shouldTrackNextIndentation = false;
-                    }
 
                     // do we need to track the indents for the next statement?
+                    shouldTrackNextIndentation = false;
                     if (isOption)
                     {
                         shouldTrackNextIndentation = true;


### PR DESCRIPTION
I am still very new to open source so please go easy on me.

A naive solution for #200.

```
<<if true>>
    -> Option1
<<else>>
    -> Option2
<<endif>>
```
This will now parse successfully.

The bug occurs because `shouldTrackNextIndentation` is set to `true` when evaluating the line `    -> Option1`, but is not set to `false` when evaluating the `<<else>>` line.  Therefore, when evaluating the line `    -> Option2` an `INDENT` get appended to the `<<else>>` statement, which causes a parse error when creating a `YarnSpinnerLexer` with this input.

The solution I came up with is to evaluate `shouldTrackNextIndentation` for every line that is parsed, instead of skipping it where a line is less indented than the shortcut option.  Logically, this makes sense to me since if the line following a shortcut option is not indented relative to it, then it is not part of the shortcut's scope.  Therefore we should stop tracking indentation.

I ask for input from those of you who are more familiar with how the parsing process work as a whole.  Please let me know if this solution works of if I am misunderstanding something.

Thank you!