### PR TITLE
Fix up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 language: csharp
 dist: trusty
 mono: none
-dotnet: 2.2.101
+dotnet: 3.0.100
 script:
   - dotnet restore
   - dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 language: csharp
 dist: trusty
 mono: none
-dotnet: 3.0.100
+dotnet: 2.1.505
 script:
   - dotnet restore
   - dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 language: csharp
 dist: trusty
 mono: none
-dotnet: 2.2.0
+dotnet: 2.2.101
 script:
   - dotnet restore
   - dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 language: csharp
 dist: trusty
 mono: none
-dotnet: 2.0.0
+dotnet: 2.2.0
 script:
   - dotnet restore
   - dotnet build


### PR DESCRIPTION
Builds on travis were failing with a crash inside the compiler, due to something that changed between 2791c75ee and 24500a6a8919. Resolved by updating the version number of the .NET SDK used in Travis builds.