### PR TITLE
Remove code tracking visited nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 
+- The 'clearVisitedNodes' parameter of Dialogue.UnloadAll
+
 ## [v1.1.0] - 2020-04-01
 
 Final release of v1.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 
-- The 'clearVisitedNodes' parameter of Dialogue.UnloadAll
-
 ## [v1.1.0] - 2020-04-01
 
 Final release of v1.1.0.

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -509,10 +509,6 @@ namespace Yarn {
         /// </remarks>
         public Library library { get; internal set; }
 
-        // The collection of nodes that we've seen.
-        // TODO: this should probably be serialized
-        private Dictionary<string, int> visitedNodeCount = new Dictionary<string, int>();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Dialogue"/> class.
         /// </summary>
@@ -659,18 +655,6 @@ namespace Yarn {
                 vm.Stop();
         }
 
-        internal IEnumerable<string> visitedNodes {
-            get {
-                return visitedNodeCount.Keys;
-            }
-            set {
-                visitedNodeCount = new Dictionary<string, int>();
-                foreach (var entry in value) {
-                    visitedNodeCount[entry] = 1;
-                }
-            }
-        }
-
         /// <summary>
         /// Gets the names of the nodes in the Program.
         /// </summary>
@@ -767,12 +751,7 @@ namespace Yarn {
         /// <summary>
         /// Unloads all nodes from the Dialogue.
         /// </summary>
-        /// <param name="clearVisitedNodes">If `true`, the internal list of
-        /// visited nodes is cleared as well.</param>
-        public void UnloadAll(bool clearVisitedNodes = true) {
-            if (clearVisitedNodes)
-                visitedNodeCount.Clear();
-
+        public void UnloadAll() {
             Program = null;
 
         }

--- a/YarnSpinner/Dialogue.cs
+++ b/YarnSpinner/Dialogue.cs
@@ -753,7 +753,6 @@ namespace Yarn {
         /// </summary>
         public void UnloadAll() {
             Program = null;
-
         }
 
         internal String GetByteCode() {


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
 - Removes untested functionality, no new test needed. Have run `TestNodeExists` to make sure clearing still works. Have also run a Unity project with the new DLL to make sure it works still.
- [x] Docs have been added / updated (for bug fixes / features)
 - Removed a line documenting the unused method parameter
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the current behavior?** (You can also link to an open issue here)
Calling `Dialogue.UnloadAll()` with the `clearVisitedNodes` parameter set to true clears an internal list of visited nodes.

* **What is the new behavior (if this is a feature change)?**
The internal list of visited nodes is removed, and there's no `clearVisitedNodes` parameter

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It.... might. I believe this changes the public API, so it might be best to accept the `clearVisitedNodes` parameter and drop it on the floor and deprecate its use as legacy. Please let me know if you'd prefer that!

* **Other information**:
None