### PR TITLE
Removed duplicate nullcheck in VirtualMachine.cs

### DIFF
--- a/YarnSpinner/VirtualMachine.cs
+++ b/YarnSpinner/VirtualMachine.cs
@@ -304,11 +304,6 @@ namespace Yarn
                 throw new DialogueException($"Cannot continue running dialogue. {nameof(nodeCompleteHandler)} has not been set.");
             }
 
-            if (nodeCompleteHandler == null)
-            {
-                throw new DialogueException($"Cannot continue running dialogue. {nameof(nodeCompleteHandler)} has not been set.");
-            }
-
             executionState = ExecutionState.Running;
 
             // Execute instructions until something forces us to stop


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

The above check boxes doesn't seem to be that applicable for this simple fix.

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [X] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
A null check on nodeCompleteHandler is called twice. Probably a copy paste error? 
Or should it check for for some other handle (dialogueCompleteHandler seems logical).


* **What is the new behavior (if this is a feature change)?**
Removed the duplicate.


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No changes in functionality, just less duplicate code.


* **Other information**:

