### PR TITLE
Automated identification of last lines before options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CompilationResult.DebugInfo` now provides per-instruction positional debug information.
   - This allows users of the `Compiler` class to access positional information for each instruction, which is an important first step for source-level debugging.
 - Made `Diagnostic` and `Declaration` serializable, for easier communication with language servers and other utilities.
+- The compiler now does a last-line-before-options tagging pass.
+  - This will add a `#lastline` tag onto any dialogue line that immediately precedes a block of options.
+  - This is intended to used by other parts of the game to modify dialogue view behaviours.
 
 ### Changed
 

--- a/YarnSpinner.Compiler/Compiler.cs
+++ b/YarnSpinner.Compiler/Compiler.cs
@@ -720,6 +720,14 @@ namespace Yarn.Compiler
                 RegisterStrings(file.FileName, stringTableManager, parseResult.Tree, ref diagnostics);
             }
 
+            // ok now we will add in our lastline tags
+            // this should probably be a flag instead of every time
+            foreach (var parsedFile in parsedFiles)
+            {
+                var lastLineTagger = new LastLineBeforeOptionsVisitor();
+                lastLineTagger.Visit(parsedFile.Tree);
+            }
+
             if (compilationJob.CompilationType == CompilationJob.Type.StringsOnly)
             {
                 // Stop at this point

--- a/YarnSpinner.Compiler/Compiler.cs
+++ b/YarnSpinner.Compiler/Compiler.cs
@@ -306,6 +306,8 @@ namespace Yarn.Compiler
         /// <param name="fileName">The name to assign to the compiled
         /// file.</param>
         /// <param name="source">The text to compile.</param>
+        /// <param name="library">Library of function definitions to use
+        /// during compilation.</param>
         /// <returns>A new <see cref="CompilationJob"/>.</returns>
         public static CompilationJob CreateFromString(string fileName, string source, Library library = null)
         {
@@ -717,15 +719,13 @@ namespace Yarn.Compiler
                 var parseResult = ParseSyntaxTree(file, ref diagnostics);
                 parsedFiles.Add(parseResult);
 
-                RegisterStrings(file.FileName, stringTableManager, parseResult.Tree, ref diagnostics);
-            }
-
-            // ok now we will add in our lastline tags
-            // this should probably be a flag instead of every time
-            foreach (var parsedFile in parsedFiles)
-            {
+                // ok now we will add in our lastline tags
+                // we do this BEFORE we build our strings table otherwise the tags will get missed
+                // this should probably be a flag instead of every time though
                 var lastLineTagger = new LastLineBeforeOptionsVisitor();
-                lastLineTagger.Visit(parsedFile.Tree);
+                lastLineTagger.Visit(parseResult.Tree);
+
+                RegisterStrings(file.FileName, stringTableManager, parseResult.Tree, ref diagnostics);
             }
 
             if (compilationJob.CompilationType == CompilationJob.Type.StringsOnly)

--- a/YarnSpinner.Compiler/LastLineBeforeOptionsVisitor.cs
+++ b/YarnSpinner.Compiler/LastLineBeforeOptionsVisitor.cs
@@ -1,0 +1,60 @@
+namespace Yarn.Compiler
+{
+    using Antlr4.Runtime;
+    using Antlr4.Runtime.Misc;
+
+    class LastLineBeforeOptionsVisitor : YarnSpinnerParserBaseVisitor<byte>
+    {
+        // tags this line as being one that is the statement immediately before an option block, does this by adding a #lastline tag onto this line
+        // no checking is needed because only lines that are needing to be tagged will be visited, others are skipped.
+        // The line is tagged regardless of if there is a #lastline there already
+        // technically unecessary in that case but this feels uncommon enough to not bother edgecasing
+        public override byte VisitLine_statement([NotNull] YarnSpinnerParser.Line_statementContext context)
+        {
+            var hashtag = new YarnSpinnerParser.HashtagContext(context, 0);
+            hashtag.text = new CommonToken(YarnSpinnerLexer.HASHTAG_TEXT, "lastline");
+            context.AddChild(hashtag);
+
+            return 0;
+        }
+
+        // finds any lines that immediately follow an option block and visits them for tagging
+        // this works by making our way through each and every statement inside of a body block performing the following:
+        // 1. assume the current statement is an option block
+        // 2. assume the statement before it is a line
+        // 3. if both of these hold true we have found a line we need to flag as being before options
+        // 4. repeat this process until we run out of statements to check
+        public override byte VisitBody([NotNull] YarnSpinnerParser.BodyContext context)
+        {
+            // starting at i = 1 is not a bug, we want to skip the first statement
+            // the first statement by definition cannot have a line before it
+            var statements = context.statement();
+            if (statements.Length < 1)
+            {
+                return 0;
+            }
+
+            for (int i = 1; i < statements.Length; i++)
+            {
+                // we aren't an option, keep moving
+                if (statements[i].shortcut_option_statement() == null)
+                {
+                    continue;
+                }
+
+                // the statement before us isn't a line, continue
+                var previous = statements[i - 1].line_statement();
+                if (previous == null)
+                {
+                    continue;
+                }
+
+                // ok now at this point we know the line that needs to be tagged as the last line
+                // we do that inside the line visitation
+                this.Visit(previous);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/YarnSpinner.Compiler/LastLineBeforeOptionsVisitor.cs
+++ b/YarnSpinner.Compiler/LastLineBeforeOptionsVisitor.cs
@@ -18,26 +18,85 @@ namespace Yarn.Compiler
             return 0;
         }
 
-        // finds any lines that immediately follow an option block and visits them for tagging
-        // this works by making our way through each and every statement inside of a body block performing the following:
+        // entry point for everything
+        // if there are no ifs or options with embedded statements this will be all that is visited
+        public override byte VisitBody([NotNull] YarnSpinnerParser.BodyContext context)
+        {
+            this.RunThroughStatements(context.statement());
+
+            return 0;
+        }
+
+        // handles the statements inside of an if statement
+        // chunks its way through the if, any else-ifs and elses internal block of statements
+        public override byte VisitIf_statement([NotNull] YarnSpinnerParser.If_statementContext context)
+        {
+            RunThroughStatements(context.if_clause().statement());
+
+            var elseifs = context.else_if_clause();
+            if (elseifs?.Length > 0)
+            {
+                foreach(var elif in elseifs)
+                {
+                    RunThroughStatements(elif.statement());
+                }
+            }
+
+            var el = context.else_clause()?.statement();
+            if (el?.Length > 0)
+            {
+                RunThroughStatements(el);
+            }
+
+            return 0;
+        }
+
+        // visiting an option
+        // basically just run through the statement (if any exist)
+        public override byte VisitShortcut_option_statement([NotNull] YarnSpinnerParser.Shortcut_option_statementContext context)
+        {
+            foreach(var shortcut in context.shortcut_option())
+            {
+                var statements = shortcut.statement();
+                if (statements?.Length > 0)
+                {
+                    RunThroughStatements(statements);
+                }
+            }
+
+            return 0;
+        }
+
+        // in the current block of statements finds any lines that immediately follow an option block and visits them for tagging
+        // this works by making our way through each and every statement inside of a block performing the following:
         // 1. assume the current statement is an option block
         // 2. assume the statement before it is a line
         // 3. if both of these hold true we have found a line we need to flag as being before options
         // 4. repeat this process until we run out of statements to check
-        public override byte VisitBody([NotNull] YarnSpinnerParser.BodyContext context)
+        // this has the potential to have VERY deep call stacks
+        private void RunThroughStatements(YarnSpinnerParser.StatementContext[] statements)
         {
-            // starting at i = 1 is not a bug, we want to skip the first statement
-            // the first statement by definition cannot have a line before it
-            var statements = context.statement();
-            if (statements.Length < 1)
+            for (int i = 0; i < statements.Length; i++)
             {
-                return 0;
-            }
+                // if we are an if-block we have to visit it in case there are options and lines inside of that
+                // once that is done we can move onto the next statement
+                if (statements[i].if_statement() != null)
+                {
+                    this.Visit(statements[i]);
+                    continue;
+                }
 
-            for (int i = 1; i < statements.Length; i++)
-            {
                 // we aren't an option, keep moving
                 if (statements[i].shortcut_option_statement() == null)
+                {
+                    continue;
+                }
+
+                // we need to visit the option in case it has embedded statements
+                this.Visit(statements[i]);
+
+                // we are an option BUT there isn't a previous statement
+                if (i == 0)
                 {
                     continue;
                 }
@@ -53,8 +112,6 @@ namespace Yarn.Compiler
                 // we do that inside the line visitation
                 this.Visit(previous);
             }
-
-            return 0;
         }
     }
 }

--- a/YarnSpinner.Compiler/StringTableGeneratorVisitor.cs
+++ b/YarnSpinner.Compiler/StringTableGeneratorVisitor.cs
@@ -131,7 +131,7 @@ namespace Yarn.Compiler
             var hashtagText = new List<string>();
             foreach (var tag in hashtags)
             {
-                hashtagText.Add(tag.HASHTAG_TEXT().GetText());
+                hashtagText.Add(tag.text.Text);
             }
 
             return hashtagText.ToArray();

--- a/YarnSpinner.Tests/TagTests.cs
+++ b/YarnSpinner.Tests/TagTests.cs
@@ -167,5 +167,16 @@ line before call #line:4
             info = result.StringTable["line:4"];
             Assert.DoesNotContain("lastline", info.metadata);
         }
+
+        [Fact]
+        void TestLineIsLastBeforeAnotherNodeNotTagged()
+        {
+            var source = "title: Start\n---\nlast line #line:0\n===\ntitle: Second\n---\n-> option 1\n===\n";
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:0"];
+            Assert.DoesNotContain("lastline", info.metadata);
+        }
     }
 }

--- a/YarnSpinner.Tests/TagTests.cs
+++ b/YarnSpinner.Tests/TagTests.cs
@@ -10,6 +10,19 @@ namespace YarnSpinner.Tests
         }
 
         [Fact]
+        void TestNoOptionsLineNotTagged()
+        {
+            var source = "title:Start\n---\nline without options #line:1\n===\n";
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:1"];
+
+            Assert.DoesNotContain("lastline",info.metadata);
+        }
+
+        [Fact]
         void TestLineBeforeOptionsTaggedLastLine()
         {
             var source = "title:Start\n---\nline before options #line:1\n-> option 1\n-> option 2\n===\n";
@@ -86,6 +99,69 @@ line before options #line:0
             Assert.Empty(result.Diagnostics);
             var info = result.StringTable["line:0"];
             Assert.Contains("lastline", info.metadata);
+        }
+        [Fact]
+        void TestIfInteriorLinesNotTaggedLastLine()
+        {
+            var source = CreateTestNode(@"
+<<if true>>
+line before options #line:0
+<<endif>>
+-> option 1
+-> option 2
+            ");
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+            var info = result.StringTable["line:0"];
+            Assert.DoesNotContain("lastline", info.metadata);
+        }
+
+        [Fact]
+        void TestNestedOptionLinesNotTagged()
+        {
+            var source = CreateTestNode(@"
+-> option 1
+    inside options #line:1a
+-> option 2
+-> option 3
+            ");
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:1a"];
+            Assert.DoesNotContain("lastline", info.metadata);
+        }
+
+        [Fact]
+        void TestInterruptedLinesNotTagged()
+        {
+            var source = CreateTestNode(@"
+line before command #line:0
+<<custom command>>
+-> option 1
+line before declare #line:1
+<<declare $value = 0>>
+-> option 1
+line before set #line:2
+<<set $value = 0>>
+-> option 1
+line before jump #line:3
+<<jump nodename>>
+            ");
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:0"];
+            Assert.DoesNotContain("lastline", info.metadata);
+            info = result.StringTable["line:1"];
+            Assert.DoesNotContain("lastline", info.metadata);
+            info = result.StringTable["line:2"];
+            Assert.DoesNotContain("lastline", info.metadata);
+            info = result.StringTable["line:3"];
+            Assert.DoesNotContain("lastline", info.metadata);
         }
     }
 }

--- a/YarnSpinner.Tests/TagTests.cs
+++ b/YarnSpinner.Tests/TagTests.cs
@@ -149,6 +149,8 @@ line before set #line:2
 -> option 1
 line before jump #line:3
 <<jump nodename>>
+line before call #line:4
+<<call function()>>
             ");
 
             var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
@@ -161,6 +163,8 @@ line before jump #line:3
             info = result.StringTable["line:2"];
             Assert.DoesNotContain("lastline", info.metadata);
             info = result.StringTable["line:3"];
+            Assert.DoesNotContain("lastline", info.metadata);
+            info = result.StringTable["line:4"];
             Assert.DoesNotContain("lastline", info.metadata);
         }
     }

--- a/YarnSpinner.Tests/TagTests.cs
+++ b/YarnSpinner.Tests/TagTests.cs
@@ -1,0 +1,91 @@
+using Xunit;
+using Yarn.Compiler;
+
+namespace YarnSpinner.Tests
+{
+    public class TagTests : TestBase
+    {
+        public TagTests() : base()
+        {
+        }
+
+        [Fact]
+        void TestLineBeforeOptionsTaggedLastLine()
+        {
+            var source = "title:Start\n---\nline before options #line:1\n-> option 1\n-> option 2\n===\n";
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:1"];
+
+            Assert.Contains("lastline",info.metadata);
+        }
+
+        [Fact]
+        void TestLineNotBeforeOptionsNotTaggedLastLine()
+        {
+            var source = "title:Start\n---\nline not before options #line:0\nline before options #line:1\n-> option 1\n-> option 2\n===\n";
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:0"];
+
+            Assert.DoesNotContain("lastline", info.metadata);
+        }
+
+        [Fact]
+        void TestLineAfterOptionsNotTaggedLastLine()
+        {
+            var source = "title:Start\n---\nline before options #line:1\n-> option 1\n-> option 2\nline after options #line:2\n===\n";
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+
+            var info = result.StringTable["line:2"];
+
+            Assert.DoesNotContain("lastline", info.metadata);
+        }
+
+        [Fact]
+        void TestNestedOptionLinesTaggedLastLine()
+        {
+            var source = CreateTestNode(@"
+line before options #line:1
+-> option 1
+    line 1a #line:1a
+    line 1b #line:1b
+    -> option 1a
+    -> option 1b
+-> option 2
+-> option 3
+            ");
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+            var info = result.StringTable["line:1"];
+            Assert.Contains("lastline", info.metadata);
+
+            info = result.StringTable["line:1b"];
+            Assert.Contains("lastline", info.metadata);
+        }
+
+        [Fact]
+        void TestIfInteriorLinesTaggedLastLine()
+        {
+            var source = CreateTestNode(@"
+<<if true>>
+line before options #line:0
+-> option 1
+-> option 2
+<<endif>>
+            ");
+
+            var result = Compiler.Compile(CompilationJob.CreateFromString("input", source));
+            Assert.Empty(result.Diagnostics);
+            var info = result.StringTable["line:0"];
+            Assert.Contains("lastline", info.metadata);
+        }
+    }
+}


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)

There is an oft expressed desire to know when a line is the last one before an option block is presented, see [this issue](https://github.com/YarnSpinnerTool/YarnSpinner-Unity/issues/88) for example.
Currently the workaround is to cache every line which is unsatisfying.

* **What is the new behavior (if this is a feature change)?**

At compile time now the compiler will add a `#lastline` tag to any line of dialogue that is before a block of options.
Meaning the following:
```
A: are we doing it?
B: Yes let's do it!
-> Ok
-> Hold on a second
```

Would become:
```
A: are we doing it?
B: Yes let's do it! #lastline
-> Ok
-> Hold on a second
```
So you can then later use this tag however you want for your games needs.

This doesn't handle every edge case (nor can it ever do so) but because it uses the tags it provides an easy means to handle such a situation.
Say for example you have the following chunk of yarn:
```
A: are we doing it?
B: Yes let's do it!

<<if $know_about_secret_entrance>>
A: Let's go around the back
<<endif>>

-> Ok
-> Hold on a second
```

The last line before the option block could be either `B: Yes let's do it!` or `A: Let's go around the back` and we can't know that at compile time.
Instead this can be manually rewritten and tagged to resolve the issue:
```
A: are we doing it?

<<if $know_about_secret_entrance>>
B: Yes let's do it!
A: Let's go around the back #lastline
<<else>>
B: Yes let's do it! #lastline
<<endif>>

-> Ok
-> Hold on a second
```

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This is a purely additive change but anyone using the #lastline tag already on their lines will experience some unusual behaviour.
Considering the ability to view metadata in [PR 146](https://github.com/YarnSpinnerTool/YarnSpinner-Unity/pull/146) was only recently merged its probably safe to assume the number of people who will have issue will be small.
Regardless if it is an issue it is easy to change to a different tag.

* **Other information**:

This works by modifying the parse tree and not actually writing these tags back onto the file, they will appear in the strings table though.
Other means to do this would be to feature some sort of runtime lookahead or lookbehind but both require substantially more work to create the exact same effect as this, so I consider them not worth it.

Additionally this could be a bit smarter and skip some elements such as `declare`, `set` and any custom command but because we can't know the side-effects of custom commands we can't really know if they are gonna do something funky that would break the promise of the tag.
As such it would be weird to go "for declare and set we will work it out but for custom commands you are on your own" so didn't do this.

I am adding my docs below because I haven't yet worked out the right spot in the docs site where they should go, but this is the basis of the documentation of the feature IMO:

# Automatic tagging of the last line before options

Automatic last line before options tagging is a process Yarn Spinner performs to identify the final line of dialogue before a block of options.
The intent of this is to allow custom dialogue views to perform any customisation your game might need before the options are presented.
The automatic last line tagging works by adding a `#lastline` hashtag onto any line of dialogue that precedes options.
Essentially this means that the following:

```Yarn
title: Start
---
here is a line right before some options

-> Option 1
-> Option 2
===
```

Gets converted without any additional work by the writers into the following:

```Yarn
title: Start
---
here is a line right before some options #lastline

-> Option 1
-> Option 2
===
```

This tagging occurs at the compilation (specifically string table generation) stage and the Yarn files themselves are unchanged.

## Using the lastline tag

The `lastline` hashtag has no special meaning or functionality inside of Yarn Spinner, after the compiler has finished it is another piece of line metadata like any other.
You must determine what (if any) needs your game has for this metadata, and it can be safely ignored if you have no needs for it.

Inside of Unity to access the lastline metadata through the `Metadata` property on the `LocalizedLine` class.

```csharp
public override void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
{
    if(Array.IndexOf(dialogueLine.Metadata,"lastline") != -1)
    {
        // this is the line before options
    }
    else
    {
        // show line normally
    }
}
```

## Caveats

The automatic tagging only works on dialogue lines that precede options, so if some other element (such as a command) in between the dialogue and options the tagger won't work.
The work around for this is to manually tag any lines.
As an example of this:

```Yarn
A: is it time?
B: I think so

<<walk to door>>

-> Lets do it
-> Give me a moment
```

Here the command `<<walk to door>>` is interrupting the automatic tagging from marking `B: I think so` as the last line before options.
This can be fixed with manually tagging the line:
```Yarn
A: is it time?
B: I think so #lastline

<<walk to door>>

-> Lets do it
-> Give me a moment
```

This is also the case for larger blocks of dialogue where the lines must change based on the needs of the story:

```Yarn
A: is it time?
B: I think so

<<if $know_some_fact>>
C: Definitely time
<<endif>>

-> Lets do it
-> Give me a moment
```

In this case we can't know if line `B: I think so` or `C: Definitely time` is to be the last line before the block of options.
The solution is to rework the Yarn into something like the following and manually tag the lines:

```Yarn
A: is it time?

<<if $know_some_fact>>
B: I think so
C: Definitely time #lastline
<<else>>
B: I think so #lastline
<<endif>>

-> Lets do it
-> Give me a moment
```

Yarn Spinner does not verify any manually `#lastline` tagged lines are actually the last line before options.