### PR TITLE
docs: Added 2to3.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ Temporary Items
 
 # Visual Studio cache directory
 .vs/
+.idea/
 
 # Gradle cache directory
 .gradle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- A document to serve as a roadmap for current and future changes until Yarn 3 is released.
+
 ### Changed
 
 - Merged LanguageServer projects into the core YarnSpinner repository.

--- a/Documentation/2to3.md
+++ b/Documentation/2to3.md
@@ -1,0 +1,14 @@
+# Yarn Spec 3 Proposals
+
+This document lists features that were accepted into the Yarn 3 language specification. If a feature is listed here, it may or may not mean that it has already been implemented by the official YarnSpinner runtime.
+
+The purpose of this document is severalfold:
+- document features that were already added to YarnSpinner since 2021-09-30 when the Yarn 2 language specification was published;
+- serve as a roadmap for future language development;
+- allow multiple language runtime implementations (including unofficial ones) to know what features are currently being developed, or will be added in the future, thus making it easier for them to implement those features at their own pace;
+- it will also make writing Yarn 3 spec much easier when we are ready to publish it.
+
+Items that are included in this list could be:
+- new language features;
+- changes to existing language features;
+- features that already exist in YarnSpinner but were not properly documented in [Yarn 2](Yarn-Spec.md) spec, or documented incorrectly.


### PR DESCRIPTION
This PR adds a placeholder document where **proposals** can be accumulated before they are implemented, serving as a roadmap and allowing to easier coordinate changes across external YarnSpinner implementations.

Closes #334

* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [ ] Feature
- [x] Something else

* **What is the new behavior (if this is a feature change)?**
This is a documentation-only change.


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

