### PR TITLE
Missing node warning and quickfixes

### DIFF
--- a/YarnSpinner.LanguageServer/src/Server/Diagnostics/ErrorCodes.cs
+++ b/YarnSpinner.LanguageServer/src/Server/Diagnostics/ErrorCodes.cs
@@ -21,6 +21,11 @@
         YRNMsngCmdDef,
 
         /// <summary>
+        /// Warning: Jump to undefined node
+        /// </summary>
+        YRNMsngJumpNode,
+
+        /// <summary>
         /// Error: Command or Function that has an incorrect number of parameters
         /// </summary>
         YRNCmdParamCnt,

--- a/YarnSpinner.LanguageServer/src/Server/Handlers/CodeActionHandler.cs
+++ b/YarnSpinner.LanguageServer/src/Server/Handlers/CodeActionHandler.cs
@@ -37,6 +37,9 @@ namespace YarnLanguageServer.Handlers
                     case nameof(YarnDiagnosticCode.YRNMsngVarDec):
                         results.AddRange(HandleYRNMsngVarDec(diagnostic, request.TextDocument.Uri));
                         break;
+                    case nameof(YarnDiagnosticCode.YRNMsngJumpNode):
+                        results.AddRange(HandleYRNMsngJumpNode(diagnostic, request.TextDocument.Uri));
+                        break;
                 }
             }
 
@@ -154,6 +157,93 @@ namespace YarnLanguageServer.Handlers
                     return replaceAction;
                 })
                 .Select(s => new CommandOrCodeAction(s));
+
+            return suggestions;
+        }
+
+        private IEnumerable<CommandOrCodeAction> HandleYRNMsngJumpNode(Diagnostic diagnostic, DocumentUri uri)
+        {
+            var jumpDestination = diagnostic.Data?.ToString();
+            if (string.IsNullOrEmpty(jumpDestination)) { return Enumerable.Empty<CommandOrCodeAction>(); }
+
+            var project = workspace.GetProjectsForUri(uri).FirstOrDefault();
+            if (project == null) { return Enumerable.Empty<CommandOrCodeAction>(); }
+
+            // Suggest potential renamings by fuzzy-searching for the existing
+            // input, and offering suggestions that replace the text.
+            var suggestions =
+                project.FindNodes(jumpDestination, true)
+                .Where(name => name != jumpDestination)
+                .Distinct()
+                .Take(10)
+                .Select(name =>
+                {
+                    var edits = new Dictionary<DocumentUri, IEnumerable<TextEdit>>();
+                    edits[uri] = new List<TextEdit> { new TextEdit { NewText = name, Range = diagnostic.Range } };
+
+                    var replaceAction = new CodeAction
+                    {
+                        Title = $"Rename to '{name}'",
+                        Kind = CodeActionKind.QuickFix,
+                        Edit = new WorkspaceEdit { Changes = edits },
+                    };
+                    return replaceAction;
+                })
+                .Select(s => new CommandOrCodeAction(s));
+
+            var yarnFile = project.GetFileData((System.Uri)uri);
+            if (yarnFile == null) { return suggestions; }
+
+            // Offer to create a new node with the missing node title if the jump destination doesn't exist
+            var insertDeclarationEdit = new Dictionary<DocumentUri, IEnumerable<TextEdit>>();
+
+            // Could share most of this code with AddNodeToDocumentAsync command
+            var newNodeText = new System.Text.StringBuilder()
+                .AppendLine($"title: {jumpDestination}")
+                .AppendLine("---")
+                .AppendLine()
+                .AppendLine("===");
+
+            Position insertPosition;
+
+            var lastLineIsEmpty = yarnFile.Text.EndsWith('\n');
+
+            int lastLineIndex = yarnFile.LineCount - 1;
+
+            if (lastLineIsEmpty)
+            {
+                // The final line ends with a newline. Insert the node
+                // there.
+                insertPosition = new Position(lastLineIndex, 0);
+            }
+            else
+            {
+                // The final line does not end with a newline. Insert a
+                // newline at the end of the last line, followed by the new
+                // text.
+                var endOfLastLine = yarnFile.GetLineLength(lastLineIndex);
+                newNodeText.Insert(0, System.Environment.NewLine);
+                insertPosition = new Position(lastLineIndex, endOfLastLine);
+            }
+
+            insertDeclarationEdit[uri] = new List<TextEdit> {
+                new TextEdit {
+                    NewText = newNodeText.ToString(),
+                    Range = new Range(insertPosition, insertPosition),
+                },
+            };
+
+            suggestions = suggestions.Prepend(
+                new CommandOrCodeAction(
+                    new CodeAction
+                    {
+                        Title = $"Generate node '{jumpDestination}'",
+                        Kind = CodeActionKind.QuickFix,
+                        IsPreferred = true,
+                        Edit = new WorkspaceEdit { Changes = insertDeclarationEdit },
+                    }
+                )
+            );
 
             return suggestions;
         }

--- a/YarnSpinner.LanguageServer/src/Server/Workspace/Project.cs
+++ b/YarnSpinner.LanguageServer/src/Server/Workspace/Project.cs
@@ -156,6 +156,12 @@ namespace YarnLanguageServer
             return FindDeclarations(Variables, name, fuzzySearch);
         }
 
+        internal IEnumerable<string> FindNodes(string name, bool fuzzySearch = false)
+        {
+            var nodeNames = this.yarnFiles.Values.SelectMany(file => file.NodeInfos.Select(node => node.Title)).Distinct();
+            return FindNodes(nodeNames, name, fuzzySearch);
+        }
+
         /// <summary>
         /// Finds actions of the given type that match a name.
         /// </summary>
@@ -296,6 +302,17 @@ namespace YarnLanguageServer
             }
 
             return Workspace.FuzzySearchItem(declarations.Select(d => (d.Name, d)), name, ConfigurationSource?.Configuration.DidYouMeanThreshold ?? Configuration.Defaults.DidYouMeanThreshold);
+        }
+
+        private IEnumerable<string> FindNodes(IEnumerable<string> nodeNames, string name, bool fuzzySearch)
+        {
+            if (fuzzySearch == false)
+            {
+                return nodeNames.Where(n => n.Equals(name));
+            }
+
+            return Workspace.FuzzySearchItem(nodeNames.Select(n => (n, n)), name, ConfigurationSource?.Configuration.DidYouMeanThreshold ?? Configuration.Defaults.DidYouMeanThreshold)
+                .Select(n => n);
         }
     }
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/YarnSpinnerTool/VSCodeExtension/issues/50


* **What is the new behavior (if this is a feature change)?**
This adds 2/3 requested improvements to the VSCode extension's handling of missing nodes:
1. Show a warning if there is a `jump` statement to a node name that  does not exist in the current project ![{C0AC4330-A3A3-4305-9CA2-7F2A940498CF}](https://github.com/user-attachments/assets/e9b0fefe-1767-4af3-94ee-ffa5abcfba65)
2. Adds code actions to either generate a stub node with that node title, or rename the jump destination if it looks like a typo of a known node name (same fuzzy matching as the undeclared variable code action).
![{B10B5891-F11F-4679-B096-75975D4372D1}](https://github.com/user-attachments/assets/68a8fbb6-f385-4299-91e7-bfb7de8ca582)

* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Marking this as a draft for now so I can procrastinate testing 😉
