### PR TITLE
Add loadExternalActionSource command to language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for variadic functions.
 - Added support for cancelling compilation.
   - To enable cancelling a compilation, supply a `CancellationToken` to your `CompilationJob` object. You can request that the compilation be cancelled by cancelling the token. For more information, see [Task Cancellation](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/task-cancellation).
+- Added a new language server command `yarnspinner.loadExternalActionSource` which can be used to programatically load command / function definitions from an external source (eg. a vscode extension that parses yarn commands/functions from a non-C# language).
 
 ### Changed
 

--- a/YarnSpinner.LanguageServer/src/Server/Commands/Commands.cs
+++ b/YarnSpinner.LanguageServer/src/Server/Commands/Commands.cs
@@ -73,4 +73,11 @@ public static class Commands
     /// The command to get all projects in the current workspace.
     /// </summary>
     public const string ListProjects = "yarnspinner.listProjects";
+
+    /// <summary>
+    /// The command to import function and command definitions from external sources.
+    /// </summary>
+    /// <param name="sourceKey">The unique key identifying the external action source.</param>
+    /// <param name="sourceContent">A string containing JSON with the same schema as the .ysls.json file.</param>
+    public const string LoadExternalActionSource = "yarnspinner.loadExternalActionSource";
 }


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
More details in the [issue link](https://github.com/YarnSpinnerTool/IssuesDiscussion/issues/25), 



* **What is the new behavior (if this is a feature change)?**
New loadExternalActionSource command can be used to load the equivalent to a ysls.json file programmatically.  


* **Does this pull request introduce a breaking change?**
Nope!



* **Other information**:
Starting this out in a draft state until tests / documentation are written and a demo of all the pieces are ready (this PR + YarnSpinner VSCode extension PR to expose the new command + a demo (or real🤞) third party VSCode that uses the new command to support a non-C# language)
