### PR TITLE
TagLines command

### DIFF
--- a/YarnSpinner.LanguageServer/src/Server/Commands/Commands.cs
+++ b/YarnSpinner.LanguageServer/src/Server/Commands/Commands.cs
@@ -50,6 +50,11 @@ public static class Commands
     public const string ExtractSpreadsheet = "yarnspinner.extract-spreadsheet";
 
     /// <summary>
+    /// The command to add tags to any lines that need them.
+    /// </summary>
+    public const string TagLines = "yarnspinner.tag-lines";
+
+    /// <summary>
     /// The command to generate a graph of the Yarn Project.
     /// Will be presented as a directed graph of nodes and jumps.
     /// </summary>


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [ ] Bug Fix
- [x] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
More details in https://github.com/YarnSpinnerTool/YarnSpinner/issues/406 but it'd be nice to apply missing line tags directly from the VS code extension (via the language server). Currently need to use unity, the ysc tool, or add line tags manually.


* **What is the new behavior (if this is a feature change)?**
This PR adds a TagLines command to the language server that takes in a link to a project (or a file in a project) and returns a workspace edit with all the text edits needed to add line tags to every untagged line in the project.


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None!


* **Other information**:
Starting this out as a draft PR until tests are added 
