### PR TITLE
Update Microsoft.CodeAnalysis.CSharp package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed an issue that would cause testplans with syntax errors to incorrectly pass.
 - Fixed an issue where using `visited()` or `visited_count()` would not correctly track visiting node groups.
 - Language Server: NodeInfo objects now indicate whether a node contains any jumps to nodes in a different file.
+- Language Server: `Microsoft.CodeAnalysis.CSharp` package updated to v4.14.0, fixing command detection in C# files using recent syntax added to C# (eg. `Required Members` from C# 11)
 
 ### Removed
 

--- a/YarnSpinner.LanguageServer.Tests/HoverTests.cs
+++ b/YarnSpinner.LanguageServer.Tests/HoverTests.cs
@@ -79,7 +79,6 @@ namespace YarnLanguageServer.Tests
 
 
             // Then
-            (hoverResult?.ToString() ?? string.Empty).Should().NotBeEmpty();
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Language.Should().Be("text");
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Value.Should().Be("instance_command_no_params");
 

--- a/YarnSpinner.LanguageServer.Tests/HoverTests.cs
+++ b/YarnSpinner.LanguageServer.Tests/HoverTests.cs
@@ -79,6 +79,7 @@ namespace YarnLanguageServer.Tests
 
 
             // Then
+            Assert.NotNull(hoverResult);
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Language.Should().Be("text");
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Value.Should().Be("instance_command_no_params");
 

--- a/YarnSpinner.LanguageServer.Tests/HoverTests.cs
+++ b/YarnSpinner.LanguageServer.Tests/HoverTests.cs
@@ -79,7 +79,7 @@ namespace YarnLanguageServer.Tests
 
 
             // Then
-
+            Assert.NotNull(hoverResult);
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Language.Should().Be("text");
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Value.Should().Be("instance_command_no_params");
 

--- a/YarnSpinner.LanguageServer.Tests/HoverTests.cs
+++ b/YarnSpinner.LanguageServer.Tests/HoverTests.cs
@@ -79,7 +79,7 @@ namespace YarnLanguageServer.Tests
 
 
             // Then
-            Assert.NotNull(hoverResult);
+            (hoverResult?.ToString() ?? string.Empty).Should().NotBeEmpty();
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Language.Should().Be("text");
             hoverResult?.Contents.MarkedStrings?.ElementAt(0).Value.Should().Be("instance_command_no_params");
 

--- a/YarnSpinner.LanguageServer.Tests/TestData/TestWorkspace/Project1/ExampleCommands.cs
+++ b/YarnSpinner.LanguageServer.Tests/TestData/TestWorkspace/Project1/ExampleCommands.cs
@@ -4,6 +4,10 @@ using System;
 
 public class ExampleCommands
 {
+    // This uses syntax from C#11 and has tripped up the CodeAnalysis.CSharp in the past
+    [Export]
+    public required Control TrapPanel { get; set; }
+
     // This is an example of a static command with no parameters, and doesn't
     // have a documentation comment. (The method is below this field to prevent
     // the parser from associating this comment with the method.)
@@ -72,7 +76,7 @@ public class ExampleCommands
 
     static class NestingTestParentClass
     {
-     
+
         [YarnCommand("command_nested_in_parent_class")]
         public static void CommandNestedInParentClass()
         {

--- a/YarnSpinner.LanguageServer.Tests/TestData/TestWorkspace/Project1/ExampleCommands.cs
+++ b/YarnSpinner.LanguageServer.Tests/TestData/TestWorkspace/Project1/ExampleCommands.cs
@@ -76,7 +76,6 @@ public class ExampleCommands
 
     static class NestingTestParentClass
     {
-
         [YarnCommand("command_nested_in_parent_class")]
         public static void CommandNestedInParentClass()
         {

--- a/YarnSpinner.LanguageServer/YarnLanguageServer.csproj
+++ b/YarnSpinner.LanguageServer/YarnLanguageServer.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.96.0" />
     <PackageReference Include="Fastenshtein" Version="1.0.0.7" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-3.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="*" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
Using the required member syntax in a C# file makes the language server unable to find command / function definitions in that file. ([reported on discord](https://discord.com/channels/754171172693868585/768556555644829696/1391441490865164388))

* **What is the new behavior (if this is a feature change)?**
New C# syntax (ie anything added since 8/12/2021) will no longer break C# command / function definition lookup.


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:

