### PR TITLE
Bugfix: Compile command should include strings and metadata for shadow lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed an issue that would cause testplans with syntax errors to incorrectly pass.
 - Fixed an issue where using `visited()` or `visited_count()` would not correctly track visiting node groups.
 - Language Server: NodeInfo objects now indicate whether a node contains any jumps to nodes in a different file.
+- Language Server: Compile workspace command output now includes metadata table and string table entries for shadow lines
 
 ### Removed
 

--- a/YarnSpinner.LanguageServer/src/Server/YarnLanguageServer.cs
+++ b/YarnSpinner.LanguageServer/src/Server/YarnLanguageServer.cs
@@ -608,12 +608,7 @@ namespace YarnLanguageServer
 
             foreach (var line in result.StringTable ?? Enumerable.Empty<KeyValuePair<string, Yarn.Compiler.StringInfo>>())
             {
-                if (line.Value.text == null)
-                {
-                    continue;
-                }
-
-                strings[line.Key] = line.Value.text;
+                strings[line.Key] = line.Value.text ?? string.Empty;
 
                 var metadataEntry = new MetadataOutput
                 {


### PR DESCRIPTION
* **Please check if the pull request fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated to describe this change

To update the documentation on [yarnspinner.dev](https://yarnspinner.dev), please visit the [documentation repository](https://github.com/YarnSpinnerTool/Docs).

* **What kind of change does this pull request introduce?**

- [x] Bug Fix
- [ ] Feature
- [ ] Something else

* **What is the current behavior?** (You can also link to an open issue here)
The output of the language server compile command does not include string table or metadata table entries for shadow lines.
This can be seen in the unknown line message for shadow lines in the VS Code extension's Dialogue Preview:
<img width="695" height="250" alt="{141E38AB-F567-4A4B-B67D-A6726AE2C403}" src="https://github.com/user-attachments/assets/86e96c3e-a696-448b-b77a-9eff8b8d4b98" />

<img width="1301" height="287" alt="{6D2A473F-59EC-483A-8868-2336A84170A2}" src="https://github.com/user-attachments/assets/825fb3b0-6fba-4f48-a421-49798998bc63" />


* **What is the new behavior (if this is a feature change)?**
The output of the language server compile command now includes string table or metadata table entries for shadow lines.
(this also make shadow lines work in the VS Code extension's Dialogue Preview)
<img width="1306" height="298" alt="{79D4639E-C66A-4C4B-8CF6-4A23DD87A1E7}" src="https://github.com/user-attachments/assets/b832df3e-9b7e-43ad-aaec-66cf91243788" />


* **Does this pull request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope, the new string / metadata entries are valid entries. The empty string in the string table is a little weird at first glance, but it matches up with what ysc outputs (and in any case, I don't think anything is using this LS command other the VSCode extension and my own private playdate extension).


* **Other information**:

